### PR TITLE
Update SpaceStation.rb

### DIFF
--- a/Prácticas/ruby/lib/SpaceStation.rb
+++ b/Prácticas/ruby/lib/SpaceStation.rb
@@ -56,7 +56,7 @@ module Deepspace
     end
 
     def speed
-      @fuelUnits/@@MAXFUEL
+      @fuelUnits.to_f/@@MAXFUEL
     end
 
     def getUIversion
@@ -82,9 +82,8 @@ module Deepspace
     end
 
     def move
-      if @fuelUnits - self.speed > 0
-        @fuelUnits= @fuelUnits - self.speed 
-      end
+      @fuelUnits-= @fuelUnits*speed   
+    end
     end
 
     def protection


### PR DESCRIPTION
Si no pones el t_f entonces hace la división entera y siempre saldra 0 o 1. 
Lo otro es que el enunciado de la practica dice que hay que restar una fraccion de @fuelUnits, por lo que hay que multiplicarlo.
Y comprobar que es negativo porque siempre estamos restando un numero menor que @fuelUnits.