### PR TITLE
Update SpaceStation.rb

### DIFF
--- a/Prácticas/ruby/lib/SpaceStation.rb
+++ b/Prácticas/ruby/lib/SpaceStation.rb
@@ -131,7 +131,7 @@ module Deepspace
     end
 
     def setPendingDamage(d)
-      @pendingDamage= Damage.newSpecificWeapons((d.adjust(@weapons, @shieldBoosters)).weapons, (d.adjust(@weapons, @shieldBoosters)).nShields)
+      @pendingDamage= d.adjust(@weapons, @shieldBoosters)
     end
 
     def validState


### PR DESCRIPTION
Ya se por qué parece que no te va!. A mi me ha pasado lo mismo xddddd.
El metodo funciona asi como lo he puesto, lo que pasa es que setPendingDamage usa @weapons!. Entonces yo estaba creando la estacion espacial y añadiendole armas con el metodo receiveWeapon(una_weapon), pero eso no las añade a @weapons. 
Lo que hay que hacer es:
crear la estacion espacial, asignarle un hangar con suficiente capacidad, añadir las armas al hangar con receiveWeapon, luego montarlas con mountWeapon, y ya si estarian en @weapons y podrias compobar bien el metodo.
Y con los shieldboosters pueh lo mismo.